### PR TITLE
Shuffle stuff around to get geoip working with -fno-common.

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -86,7 +86,7 @@ static int hourly_syscheck;
 static int hourly_firewall;
 
 #ifdef LIBGEOIP_ENABLED
-    MMDB_s geoipdb;
+    extern MMDB_s geoipdb;
 #endif
 
 

--- a/src/analysisd/config.h
+++ b/src/analysisd/config.h
@@ -12,17 +12,15 @@
 
 #include "config/config.h"
 #include "config/global-config.h"
+/*
 #ifdef LIBGEOIP_ENABLED
 #include <maxminddb.h>
 #endif
+*/
 
 
 extern long int __crt_ftell; /* Global ftell pointer */
 extern _Config Config;       /* Global Config structure */
-
-#ifdef LIBGEOIP_ENABLED
-MMDB_s geoipdb;
-#endif
 
 int GlobalConf(const char *cfgfile);
 

--- a/src/analysisd/decoders/geoip.c
+++ b/src/analysisd/decoders/geoip.c
@@ -23,10 +23,12 @@
 #include "decoder.h"
 #include <maxminddb.h>
 
+//extern MMDB_s geoipdb;
 
 char *GetGeoInfobyIP(char *ip_addr)
 {
 
+    extern MMDB_s geoipdb;
     //debug1("%s: DEBUG: Entered GetGeoInfobyIP", __local_name);
 
     if(!ip_addr)

--- a/src/analysisd/lists_make.c
+++ b/src/analysisd/lists_make.c
@@ -17,7 +17,6 @@
 #include <errno.h>
 #include "lists_make.h"
 
-
 void Lists_OP_MakeAll(int force)
 {
     ListNode *lnode = OS_GetFirstList();

--- a/src/analysisd/os_geoip.c
+++ b/src/analysisd/os_geoip.c
@@ -1,0 +1,4 @@
+#ifdef LIBGEOIP_ENABLED
+#include <maxminddb.h>
+MMDB_s geoipdb;
+#endif

--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -63,7 +63,10 @@ static void help_logtest(void)
 
 int main(int argc, char **argv)
 {
+#ifdef LIBGEOIP_ENABLED
     extern MMDB_s geoipdb;
+#endif
+
     int test_config = 0;
     int c = 0;
     char *ut_str = NULL;

--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -28,11 +28,12 @@
 #include "fts.h"
 #include "cleanevent.h"
 
+#ifdef LIBGEOIP_ENABLED
+#include <maxminddb.h>
+#endif
+
 /** Internal Functions **/
 void OS_ReadMSG(char *ut_str);
-#ifdef LIBGEOIP_ENABLED
-    MMDB_s geoipdb;
-#endif
 
 /* Analysisd function */
 RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node);
@@ -62,6 +63,7 @@ static void help_logtest(void)
 
 int main(int argc, char **argv)
 {
+    extern MMDB_s geoipdb;
     int test_config = 0;
     int c = 0;
     char *ut_str = NULL;


### PR DESCRIPTION
This is a twisty maze of junk and this wasn't as fun as I had hoped
it would be.
Essentially ossec-analysisd and ossec-makelists need the geoipdb definition. makelists doesn't pull in `analysisd.c`, but analysisd pulled in `lists_make.c` or something. So it couldn't easily be defined in both places. This is a bad hack, but it's the best I got right now.

Addresses issue #7 